### PR TITLE
Add 'ipv4_forwarding'/'ipv6_forwarding' parameters, and 'global' role.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,19 @@ The **second number** is incremented with each release, starting at 1
 for each year.
 
 The **third number** is for fixes made against older releases (only
-for emergencies).
+for emergencies or non-content releases).
 
 ## [Unreleased]
 
+## [24.2.0] - 2024-12-18
+
 ### Added
 
-- Added testing against Python 3.13 (beta).
+- Added testing against Python 3.13.
+- Added 'global' role for global configuration.
+- Added 'ipv4_forwarding' and 'ipv6_forwarding' parameters, available
+  in 'global' and 'network' roles (note: these parameters are only
+  usable with systemd version 256 and higher).
 
 ## [24.1.1] - 2024-02-17
 

--- a/src/roles/global/README.md
+++ b/src/roles/global/README.md
@@ -1,0 +1,1 @@
+Documentation for this role can be found [here](https://kpfleming.github.io/ansible-systemd-networkd).

--- a/src/roles/global/defaults/main.yml
+++ b/src/roles/global/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+systemd_root: ""
+suppress_reload: false

--- a/src/roles/global/handlers/main.yml
+++ b/src/roles/global/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: reload
+  become: true
+  when: not suppress_reload
+  ansible.builtin.command:
+    argv:
+      - networkctl
+      - reload

--- a/src/roles/global/meta/argument_specs.yml
+++ b/src/roles/global/meta/argument_specs.yml
@@ -1,0 +1,35 @@
+---
+argument_specs:
+  main:
+    short_description: Manages systemd-networkd global configuration.
+    description:
+      - |
+        This role will create (or update) a dropin file named ansible.conf in /etc/systemd/networkd.conf.d
+
+      - |
+        Sets fact named 'systemd_networkd_global_changed' to either true or false to indicate whether
+        any changes were made.
+    options:
+      suppress_reload:
+        description: Suppress the reloading of systemd-networkd if changes are made.
+        type: bool
+        default: false
+      systemd_root:
+        description: Root path of filesystem containing systemd-networkd configuration files.
+        type: str
+        default: ""
+      settings:
+        description: Settings to be applied globally.
+        type: dict
+        required: true
+        options:
+          network:
+            description: Settings for the Network section.
+            type: dict
+            options:
+              ipv4_forwarding:
+                description: Enable IPv4 forwarding.
+                type: bool
+              ipv6_forwarding:
+                description: Enable IPv6 forwarding.
+                type: bool

--- a/src/roles/global/meta/main.yml
+++ b/src/roles/global/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Kevin P, Fleming <kevin@km6g.us> @kpfleming:irc/libera.chat
+  description: Role to manage gloabl configuration of systemd-networkd.
+  license: Apache-2.0
+  issue_tracker_url: https://github.com/kpfleming/ansible-systemd-networkd/issues
+  min_ansible_version: "6.0"
+  platforms:
+    - name: GenericLinux
+  galaxy_tags:
+    - systemd
+    - network

--- a/src/roles/global/tasks/main.yml
+++ b/src/roles/global/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: manage global dropin directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ systemd_root ~ '/etc/systemd/networkd.conf.d' }}"
+    state: directory
+    mode: u=rwx,g=rx,o=
+    group: systemd-network
+
+- name: manage global configuration
+  become: true
+  register: _global
+  notify: "{{ ansible_role_name ~ ' : reload' }}"
+  ansible.builtin.template:
+    src: networkd.conf.j2
+    dest: "{{ systemd_root ~ '/etc/systemd/networkd.conf.d/ansible.conf' }}"
+    mode: u=rw,g=r,o=
+    group: systemd-network
+
+- name: set fact to indicate result
+  ansible.builtin.set_fact:
+    systemd_networkd_global_changed: "{{ systemd_networkd_global_changed|default(false) or _global.changed }}"
+
+- name: run handlers if needed
+  ansible.builtin.meta: flush_handlers

--- a/src/roles/global/templates/networkd.conf.j2
+++ b/src/roles/global/templates/networkd.conf.j2
@@ -1,0 +1,14 @@
+{% if "network" in settings -%}
+[Network]
+{% for arg, value in settings.network.items() if arg in network_arguments.keys() %}
+{% if value is string or value is integer %}
+{{ network_arguments[arg] }}={{ value }}
+{% elif value is boolean %}
+{{ network_arguments[arg] }}={{ value|ternary('yes','no') }}
+{% else %}
+{% for v in value %}
+{{ network_arguments[arg] }}={{ v }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/src/roles/network/meta/argument_specs.yml
+++ b/src/roles/network/meta/argument_specs.yml
@@ -77,6 +77,12 @@ argument_specs:
               - ipv6
               - true
               - false
+          ipv4_forwarding:
+            description: Enable forwarding of packets that arrive on this network.
+            type: bool
+          ipv6_forwarding:
+            description: Act as a host (false) or router (true).
+            type: bool
           ipv6_proxy_ndp:
             description: Configure Proxy NDP support on the network.
             type: bool

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands_pre=
     jinjanate -o src/galaxy.yml workflow-support/templates/galaxy.yml.j2
     jinjanate -o src/roles/bond/vars/main.yml workflow-support/templates/bond-vars.yml.j2 workflow-support/parameter_mapping.yml
     jinjanate -o src/roles/dummy/vars/main.yml workflow-support/templates/dummy-vars.yml.j2 workflow-support/parameter_mapping.yml
+    jinjanate -o src/roles/global/vars/main.yml workflow-support/templates/global-vars.yml.j2 workflow-support/parameter_mapping.yml
     jinjanate -o src/roles/link/vars/main.yml workflow-support/templates/link-vars.yml.j2 workflow-support/parameter_mapping.yml
     jinjanate -o src/roles/network/vars/main.yml workflow-support/templates/network-vars.yml.j2 workflow-support/parameter_mapping.yml
     jinjanate -o src/roles/tunnel/vars/main.yml workflow-support/templates/tunnel-vars.yml.j2 workflow-support/parameter_mapping.yml

--- a/workflow-support/parameter_mapping.yml
+++ b/workflow-support/parameter_mapping.yml
@@ -42,6 +42,10 @@ link_arguments:
   name: Name
   name_policy: NamePolicy
 
+global_network_arguments:
+  ipv4_forwarding: IPv4Forwarding
+  ipv6_forwarding: IPv6Forwarding
+
 network_arguments:
   bind_carrier: BindCarrier
   configure_without_carrier: ConfigureWithoutCarrier
@@ -49,6 +53,8 @@ network_arguments:
   dns: DNS
   emit_lldp: EmitLLDP
   ip_forward: IPForward
+  ipv4_forwarding: IPv4Forwarding
+  ipv6_forwarding: IPv6Forwarding
   ipv6_accept_ra: IPv6AcceptRA
   ipv6_proxy_ndp: IPv6ProxyNDP
   ipv6_proxy_ndp_address: IPv6ProxyNDPAddress

--- a/workflow-support/templates/global-vars.yml.j2
+++ b/workflow-support/templates/global-vars.yml.j2
@@ -1,0 +1,2 @@
+---
+network_arguments: {{ global_network_arguments }}


### PR DESCRIPTION
These are necessary for users of systemd 256 (or higher) to manage packet forwarding, as the existing 'ip_forward' parameter is deprecated in that version of systemd (and isn't backward compatible even if it is left in place).

Closes #38.