### PR TITLE
Add table parameter for network route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ for emergencies or non-content releases).
 
 ## [Unreleased]
 
+- Added `table` parameter to the options of the elements of `routes` in
+  the `network` role.
+
 ## [25.2.0] - 2025-01-11
 
 ### Added

--- a/src/roles/network/meta/argument_specs.yml
+++ b/src/roles/network/meta/argument_specs.yml
@@ -232,6 +232,9 @@ argument_specs:
               mtu_bytes:
                 description: The MTU to be applied to this route.
                 type: str
+              table:
+                description: The routing table to add this route to.
+                type: str
           dhcpv4:
             description: Attributes of the DHCPv4 client on the network.
             type: dict

--- a/workflow-support/parameter_mapping.yml
+++ b/workflow-support/parameter_mapping.yml
@@ -87,6 +87,7 @@ network_route_arguments:
   scope: Scope
   source: Source
   type: Type
+  table: Table
 
 network_dhcpv4_arguments:
   client_identifier: ClientIdentifier


### PR DESCRIPTION
Allows to use the systemd parameter `Table` specified in the `[Route]` section of a `.network` file.