### PR TITLE
Ensure that 'bond' and 'link' handlers work on non-Debian systems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ for emergencies or non-content releases).
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed handlers in 'bond' and 'link' roles to work properly on
+  non-Debian systems (issue 49).
+
 ## [25.3.0] - 2025-02-15
 
 ### Added

--- a/src/roles/bond/handlers/main.yml
+++ b/src/roles/bond/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: reload
   become: true
   when:
-    - not systemd_networkd_link_reboot_required
+    - not systemd_networkd_link_reboot_required|default(false)
     - not suppress_reload
   ansible.builtin.command:
     argv:

--- a/src/roles/link/handlers/main.yml
+++ b/src/roles/link/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: reload
   become: true
   when:
-    - not systemd_networkd_link_reboot_required
+    - not systemd_networkd_link_reboot_required|default(false)
     - not suppress_reload
   ansible.builtin.command:
     argv:


### PR DESCRIPTION
Closes issue #49.