### PR TITLE
Add support for 'async' reload in 'network' role.

### DIFF
--- a/src/roles/network/defaults/main.yml
+++ b/src/roles/network/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 systemd_root: ""
 suppress_reload: false
+async_reload: false

--- a/src/roles/network/handlers/main.yml
+++ b/src/roles/network/handlers/main.yml
@@ -1,7 +1,23 @@
 ---
-- name: reload
+- name: reload (sync)
   become: true
-  when: not suppress_reload
+  when:
+    - not suppress_reload
+    - not async_reload
+  listen: reload
+  ansible.builtin.command:
+    argv:
+      - networkctl
+      - reload
+
+- name: reload (async)
+  become: true
+  when:
+    - not suppress_reload
+    - async_reload
+  listen: reload
+  async: 5
+  poll: 0
   ansible.builtin.command:
     argv:
       - networkctl

--- a/src/roles/network/meta/argument_specs.yml
+++ b/src/roles/network/meta/argument_specs.yml
@@ -22,6 +22,14 @@ argument_specs:
         description: Suppress the reloading of systemd-networkd if changes are made.
         type: bool
         default: false
+      async_reload:
+        description: |
+          Issues a reload asynchronously when one is needed; this can
+          be used when the configuration change has changed the IP
+          address of the network that Ansible is using to manage the
+          system.
+        type: bool
+        default: false
       systemd_root:
         description: Root path of filesystem containing systemd-networkd configuration files.
         type: str


### PR DESCRIPTION
When the 'network' role is used to change the address of the network that Ansible is using to manage the system, a synchronous reload will hang forever while Ansible tries to connect to the old address. Using an 'async' reload allows Ansible to rediscover the system's address and make a new connection.

Closes #51.