### PR TITLE
Add support for keyed tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ for emergencies or non-content releases).
 
 ## [Unreleased]
 
+- Added support for `key`, `input_key` and `output_key` options in `tunnel`
+  role.
+
 ## [25.8.0] - 2025-09-09
 
 ### Changed

--- a/src/roles/tunnel/meta/argument_specs.yml
+++ b/src/roles/tunnel/meta/argument_specs.yml
@@ -67,6 +67,15 @@ argument_specs:
               ttl:
                 description: Time-To-Live for tunneled packets.
                 type: int
+              key:
+                description: Tunnel key to use in both directions (input and output) if using VTI/VTI6, GRE, GRETAP or ERSPAN tunnel. Must be an integer or an IPv4 address-like dotted quad.
+                type: str
+              input_key:
+                description: Tunnel key to use for input traffic if using VTI/VTI6, GRE, GRETAP or ERSPAN tunnel. Must be an integer or an IPv4 address-like dotted quad.
+                type: str
+              output_key:
+                description: Tunnel key to use for output traffic if using VTI/VTI6, GRE, GRETAP or ERSPAN tunnel. Must be an integer or an IPv4 address-like dotted quad.
+                type: str
           netdev:
             description: Attributes of the tunnel network device.
             type: dict

--- a/workflow-support/parameter_mapping.yml
+++ b/workflow-support/parameter_mapping.yml
@@ -41,6 +41,9 @@ tunnel_arguments:
   local: Local
   remote: Remote
   ttl: TTL
+  key: Key
+  input_key: InputKey
+  output_key: OutputKey
 
 link_arguments:
   mac_address_policy: MACAddressPolicy


### PR DESCRIPTION
As documented in `systemd.netdev`, the `[Tunnel]` section of a systemd netdev file supports parameters `Key`, `InputKey` and `OutputKey` for certain types of tunnels. This contribution adds the corresponding support in the associated `tunnel` role.